### PR TITLE
Check if component is mounted before setting state.

### DIFF
--- a/mixinReactProxy.js
+++ b/mixinReactProxy.js
@@ -16,7 +16,9 @@ module.exports = function(React, desc) {
 	desc.componentDidMount = function() {
 		if(!this.state.component) {
 			this.loadComponent(function(component) {
-				this.setState({ component: component });
+				if(this.isMounted()) {
+					this.setState({ component: component });
+				}
 			}.bind(this));
 		}
 	};


### PR DESCRIPTION
Prevents "Uncaught Error: Invariant Violation: replaceState(...): Can
only update a mounted or mounting component." -- which can occur if the
proxy component is unmounted before download completes.