### PR TITLE
quick & dirty interop for babel's module format

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports.pitch = function(remainingRequest) {
 		'		if(!component) {',
 		'			require.ensure([], function() {',
 		'				component = require(' + loaderUtils.stringifyRequest(this, moduleRequest) + ');',
+		'				if(typeof component === "object" && component.default) component = component.default;',
 		'				if(callback) callback(component);',
 		'			}' + (query.name ? ', ' + JSON.stringify(query.name) : '') + ');',
 		'		} else if(callback) callback(component);',


### PR DESCRIPTION
As of Babel 6, they are now formatting all es6/2015 modules as an object of named exports... if you use the export expression, the module.exports will be an object with names of your exports... if so export default React.createClass(...) is now represented as {default: ...}